### PR TITLE
Add constants module and use DB path

### DIFF
--- a/scripts/bitcoin_m2_chart.py
+++ b/scripts/bitcoin_m2_chart.py
@@ -15,6 +15,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Tuple
 
+from scripts.constants import DB_PATH_DEFAULT
+
 import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -29,7 +31,7 @@ def fetch_series(
     end: datetime,
     btc_series: str,
     m2_series: str,
-    db_path: str | Path = Path("data/fred.db"),
+    db_path: str | Path = DB_PATH_DEFAULT,
 ) -> Tuple[pd.DataFrame, pd.DataFrame]:
     """Load Bitcoin and M2 series from a local SQLite DB."""
     df = fetch_series_db([btc_series, m2_series], start, end, db_path)
@@ -113,7 +115,10 @@ def main(argv: list[str] | None = None) -> plt.Figure:
         "--extend-years", type=int, default=1, help="years beyond end date to show"
     )
     p.add_argument(
-        "--db", type=str, default="data/fred.db", help="path to local SQLite DB"
+        "--db",
+        type=str,
+        default=str(DB_PATH_DEFAULT),
+        help="path to local SQLite DB",
     )
     p.add_argument(
         "--output", type=str, default=None, help="optional path to save the figure"

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -5,6 +5,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Iterable
 
+from scripts.constants import DB_PATH_DEFAULT
+
 import matplotlib.pyplot as plt
 import pandas as pd
 import sqlite3
@@ -28,7 +30,7 @@ def fetch_series_db(
     series: Iterable[str],
     start: datetime,
     end: datetime,
-    db_path: str | Path = Path("data/fred.db"),
+    db_path: str | Path = DB_PATH_DEFAULT,
 ) -> pd.DataFrame:
     """
     Load one or more FRED series from a local SQLite DB.

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -1,0 +1,5 @@
+from pathlib import Path
+
+DB_PATH_DEFAULT = Path("data/fred.db")
+UNRATE = "UNRATE"
+DCOILWTICO = "DCOILWTICO"

--- a/scripts/custom_chart.py
+++ b/scripts/custom_chart.py
@@ -15,6 +15,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Iterable
 
+from scripts.constants import DB_PATH_DEFAULT
+
 import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -27,7 +29,7 @@ def fetch_series_multi(
     series: Iterable[str],
     start: datetime,
     end: datetime,
-    db_path: str | Path = Path("data/fred.db"),
+    db_path: str | Path = DB_PATH_DEFAULT,
 ) -> pd.DataFrame:
     """Load one or more FRED series from a local SQLite DB."""
     return fetch_series_db(series, start, end, db_path)
@@ -63,7 +65,12 @@ def main(argv: list[str] | None = None) -> plt.Figure:
         default=datetime.today().strftime("%Y-%m-%d"),
         help="end date YYYY-MM-DD",
     )
-    p.add_argument("--db", type=str, default="data/fred.db", help="path to SQLite DB")
+    p.add_argument(
+        "--db",
+        type=str,
+        default=str(DB_PATH_DEFAULT),
+        help="path to SQLite DB",
+    )
     p.add_argument(
         "--output",
         type=str,

--- a/scripts/refresh_data.py
+++ b/scripts/refresh_data.py
@@ -20,13 +20,15 @@ import sqlite3
 from pandas_datareader.data import DataReader
 import pandas as pd
 
+from scripts.constants import DB_PATH_DEFAULT, UNRATE, DCOILWTICO
+
 HERE = pathlib.Path(__file__).resolve().parent
-DATA_PATH = HERE.parent / "data"
-DB_FILE = DATA_PATH / "fred.db"
+DATA_PATH = DB_PATH_DEFAULT.parent
+DB_FILE = DB_PATH_DEFAULT
 
 DEFAULT_START = "1948-01-01"  # earliest UNRATE observation
 DEFAULT_END = date.today().isoformat()
-DEFAULT_SERIES = ("UNRATE", "DCOILWTICO")
+DEFAULT_SERIES = (UNRATE, DCOILWTICO)
 
 
 def main(argv: list[str] | None = None) -> None:


### PR DESCRIPTION
## Summary
- centralize shared constants like `DB_PATH_DEFAULT`, `UNRATE`, `DCOILWTICO`
- reference the constants from chart scripts and refresh script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b13f97fac832b88bd8ef2b86a65eb