### PR TITLE
Fix plot-custom tab indent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ plot:
 # Custom plot of arbitrary series
 # Usage: make plot-custom ARGS="--series UNRATE CPIAUCSL --start 2000-01-01"
 plot-custom:
-        ./startup.sh python scripts/custom_chart.py $(ARGS)
+	./startup.sh python scripts/custom_chart.py $(ARGS)
 
 # Run tests
 test:


### PR DESCRIPTION
## Summary
- fix indentation for `plot-custom` command in Makefile

## Testing
- `./startup.sh pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b15d941b4832bafa106b14326c400