### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Cache wheelhouse
+        uses: actions/cache@v4
+        with:
+          path: wheelhouse
+          key: wheelhouse-${{ runner.os }}-${{ hashFiles('wheelhouse/*.whl') }}
+          restore-keys: |
+            wheelhouse-${{ runner.os }}-
+
+      - name: Run tests
+        env:
+          PIP_FIND_LINKS: wheelhouse
+          PIP_NO_INDEX: '1'
+        run: |
+          chmod +x startup.sh
+          ./startup.sh pytest -q


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run tests via `startup.sh`
- cache dependency wheels

## Testing
- `PIP_FIND_LINKS=wheelhouse PIP_NO_INDEX=1 ./startup.sh pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b4a28732c832ba257e557e537e267