### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache wheelhouse
+        uses: actions/cache@v4
+        with:
+          path: wheelhouse
+          key: wheelhouse-${{ runner.os }}-${{ hashFiles('wheelhouse/*.whl') }}
+          restore-keys: |
+            wheelhouse-${{ runner.os }}-
+
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Run tests
+        env:
+          PIP_FIND_LINKS: wheelhouse
+        run: |
+          chmod +x startup.sh
+          ./startup.sh pytest -q

--- a/startup.sh
+++ b/startup.sh
@@ -16,7 +16,11 @@ DEFAULT_MODULE="scripts.lagged_oil_unrate_chart_styled"
 
 # 1) Ensure pip & setuptools are up to date
 echo "🛠 Upgrading pip & setuptools…"
-pip install --upgrade pip setuptools
+if [[ "${PIP_NO_INDEX:-}" == "1" ]]; then
+  echo "🔒 Offline mode detected; skipping upgrade"
+else
+  pip install --upgrade pip setuptools
+fi
 
 # 2) Install project dependencies globally
 echo "📦 Installing dependencies from $REQ_FILE…"


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run tests via `startup.sh`
- skip pip upgrades when offline
- remove an accidental chart image

## Testing
- `PIP_FIND_LINKS=wheelhouse PIP_NO_INDEX=1 ./startup.sh pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_683b4a28732c832ba257e557e537e267