### PR TITLE
Use local virtualenv in startup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Byte-code / venv
 __pycache__/
 venv/
+.venv/
 
 # Local data & wheels
 wheelhouse/*.log

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ cd python_charts
 
 This will:
 
-1. Upgrade `pip` & `setuptools` globally
-2. Install required packages from `requirements.txt` via
+1. Create a `.venv` virtual environment (if needed) and upgrade `pip` & `setuptools` inside it
+2. Install required packages from `requirements.txt` into that environment via
 
    ```bash
    pip install --upgrade -r requirements.txt
@@ -247,7 +247,7 @@ Once the data is present, generate the Bitcoin‐Global M2 overlay chart:
 
 ## 📦 Dependencies
 
-All Python dependencies are listed in `requirements.txt` and are installed by `./startup.sh`:
+All Python dependencies are listed in `requirements.txt` and are installed by `./startup.sh` into `.venv`:
 
 ```text
 pandas>=1.5.0

--- a/startup.sh
+++ b/startup.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # -------------------------------------------------------------------
-# startup.sh  — install deps globally, fetch data, then run command
+# startup.sh  — install deps in .venv, fetch data, then run command
 # Usage:
 #   ./startup.sh [options]       # passes options to default plot script
-#   ./startup.sh <script> [args] # runs specified script with system Python
+#   ./startup.sh <script> [args] # runs specified script with venv Python
 # Examples:
 #   ./startup.sh --offset 12 --end 2025-05-31 --extend-years 5
 #   ./startup.sh pytest -q
@@ -13,6 +13,15 @@ set -euo pipefail
 REQ_FILE="requirements.txt"
 DATA_DB="data/fred.db"
 DEFAULT_MODULE="scripts.lagged_oil_unrate_chart_styled"
+VENV_DIR=".venv"
+
+# 0) Create or activate virtual environment
+if [[ ! -d "$VENV_DIR" ]]; then
+  echo "📂 Creating virtual environment in $VENV_DIR…"
+  python -m venv "$VENV_DIR"
+fi
+# shellcheck source=/dev/null
+source "$VENV_DIR/bin/activate"
 
 # 1) Ensure pip & setuptools are up to date
 echo "🛠 Upgrading pip & setuptools…"
@@ -22,7 +31,7 @@ else
   pip install --upgrade pip setuptools
 fi
 
-# 2) Install project dependencies globally
+# 2) Install project dependencies in the venv
 echo "📦 Installing dependencies from $REQ_FILE…"
 pip install --upgrade -r "$REQ_FILE"
 


### PR DESCRIPTION
## Summary
- create or activate `.venv` in `startup.sh` and install deps there
- describe `.venv` usage in README
- ignore `.venv` directory in git

## Testing
- `PIP_NO_INDEX=1 PIP_FIND_LINKS=wheelhouse ./startup.sh pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b63bdf158832ba80bf8f749474aca