### PR TITLE
Use logging for script messages

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -6,6 +6,9 @@ from pathlib import Path
 from typing import Iterable
 
 from scripts.constants import DB_PATH_DEFAULT
+import logging
+
+logger = logging.getLogger(__name__)
 
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -22,7 +25,7 @@ def save_figure(fig: plt.Figure, output: str | None, script_path: str) -> Path:
     )
     out_path.parent.mkdir(parents=True, exist_ok=True)
     fig.savefig(out_path)
-    print(f"Saved figure to {out_path}")
+    logger.info("Saved figure to %s", out_path)
     return out_path
 
 

--- a/scripts/lagged_oil_unrate_chart_styled.py
+++ b/scripts/lagged_oil_unrate_chart_styled.py
@@ -14,6 +14,9 @@ from __future__ import annotations
 import argparse
 from datetime import datetime
 from pathlib import Path
+import logging
+
+logger = logging.getLogger(__name__)
 
 from scripts.constants import DB_PATH_DEFAULT, UNRATE, DCOILWTICO
 
@@ -98,11 +101,21 @@ def plot_lagged(
     common_start = max(unrate.index.min(), oil.index.min())
     common_end = min(unrate.index.max(), oil.index.max())
 
-    print(f"⚠️ Using overlapping range: {common_start.date()} to {common_end.date()}")
-    print(
-        f"  - UNRATE range: {unrate.index.min().date()} to {unrate.index.max().date()}"
+    logger.info(
+        "\u26a0\ufe0f Using overlapping range: %s to %s",
+        common_start.date(),
+        common_end.date(),
     )
-    print(f"  - OIL    range: {oil.index.min().date()} to {oil.index.max().date()}")
+    logger.info(
+        "  - UNRATE range: %s to %s",
+        unrate.index.min().date(),
+        unrate.index.max().date(),
+    )
+    logger.info(
+        "  - OIL    range: %s to %s",
+        oil.index.min().date(),
+        oil.index.max().date(),
+    )
 
     # Trim series to common range
     unrate_common = unrate.loc[common_start:common_end]

--- a/scripts/refresh_data.py
+++ b/scripts/refresh_data.py
@@ -16,6 +16,9 @@ from datetime import date
 import argparse
 import pathlib
 import sqlite3
+import logging
+
+logger = logging.getLogger(__name__)
 
 from pandas_datareader.data import DataReader
 import pandas as pd
@@ -46,11 +49,15 @@ def main(argv: list[str] | None = None) -> None:
     DATA_PATH.mkdir(exist_ok=True)
     with sqlite3.connect(DB_FILE) as conn:
         for s in args.series:
-            print(f"↯ downloading {s} …")
+            logger.info("\u21af downloading %s …", s)
             df = DataReader(s, "fred", args.start, args.end)
             df.to_sql(s, conn, if_exists="replace", index_label="date")
-            print(f"✓ wrote {s}: {len(df):,} rows")
-    print(f"\nDone.  SQLite DB at {DB_FILE} ({DB_FILE.stat().st_size/1024:.0f} KB)")
+            logger.info("\u2713 wrote %s: %s rows", s, len(df))
+    logger.info(
+        "\nDone.  SQLite DB at %s (%s KB)",
+        DB_FILE,
+        DB_FILE.stat().st_size / 1024,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace `print` calls with `logging` in `save_figure`
- log overlap info in `lagged_oil_unrate_chart_styled`
- log download progress in `refresh_data`

## Testing
- `PIP_NO_INDEX=1 ./startup.sh pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b6b292740832b82e633e5ed1e8af3