### PR TITLE
Add error handling for invalid date inputs

### DIFF
--- a/scripts/bitcoin_m2_chart.py
+++ b/scripts/bitcoin_m2_chart.py
@@ -14,6 +14,7 @@ import argparse
 from datetime import datetime
 from pathlib import Path
 from typing import Tuple
+import sys
 
 from scripts.constants import DB_PATH_DEFAULT
 
@@ -147,8 +148,17 @@ def main(argv: list[str] | None = None) -> plt.Figure:
     p.add_argument("--no-show", action="store_true", help="do not display the figure")
     args = p.parse_args(argv)
 
-    start_dt = datetime.fromisoformat(args.start)
-    end_dt = datetime.fromisoformat(args.end)
+    try:
+        start_dt = datetime.fromisoformat(args.start)
+    except ValueError:
+        print(f"Invalid --start date: {args.start}", file=sys.stderr)
+        raise SystemExit(1)
+
+    try:
+        end_dt = datetime.fromisoformat(args.end)
+    except ValueError:
+        print(f"Invalid --end date: {args.end}", file=sys.stderr)
+        raise SystemExit(1)
 
     btc, m2 = fetch_series(start_dt, end_dt, args.btc_series, args.m2_series, args.db)
     validate_series(btc, m2, args.btc_series, args.m2_series)

--- a/scripts/custom_chart.py
+++ b/scripts/custom_chart.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import argparse
 from datetime import datetime
+import sys
 from pathlib import Path
 from typing import Iterable
 
@@ -79,8 +80,17 @@ def main(argv: list[str] | None = None) -> plt.Figure:
     )
     args = p.parse_args(argv)
 
-    start_dt = datetime.fromisoformat(args.start)
-    end_dt = datetime.fromisoformat(args.end)
+    try:
+        start_dt = datetime.fromisoformat(args.start)
+    except ValueError:
+        print(f"Invalid --start date: {args.start}", file=sys.stderr)
+        raise SystemExit(1)
+
+    try:
+        end_dt = datetime.fromisoformat(args.end)
+    except ValueError:
+        print(f"Invalid --end date: {args.end}", file=sys.stderr)
+        raise SystemExit(1)
 
     data = fetch_series_multi(args.series, start_dt, end_dt, args.db)
     fig = plot_series(data)

--- a/scripts/lagged_oil_unrate_chart_styled.py
+++ b/scripts/lagged_oil_unrate_chart_styled.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import argparse
 from datetime import datetime
 from pathlib import Path
+import sys
 import logging
 
 logger = logging.getLogger(__name__)
@@ -255,8 +256,17 @@ def main(argv: list[str] | None = None) -> plt.Figure:
     p.add_argument("--no-show", action="store_true", help="do not display the figure")
     args = p.parse_args(argv)
 
-    start_dt = datetime.fromisoformat(args.start)
-    end_dt = datetime.fromisoformat(args.end)
+    try:
+        start_dt = datetime.fromisoformat(args.start)
+    except ValueError:
+        print(f"Invalid --start date: {args.start}", file=sys.stderr)
+        raise SystemExit(1)
+
+    try:
+        end_dt = datetime.fromisoformat(args.end)
+    except ValueError:
+        print(f"Invalid --end date: {args.end}", file=sys.stderr)
+        raise SystemExit(1)
 
     # ───────────────────────────────────────────────────────────────────────
     # Fetch both UNRATE and oil; UNRATE may contain NaNs if the last


### PR DESCRIPTION
## Summary
- validate CLI dates in `bitcoin_m2_chart`, `custom_chart`, and `lagged_oil_unrate_chart_styled`
- print a clear error message when dates are invalid

## Testing
- `./startup.sh pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b7cb93880832b8338f0efdd650331