### PR TITLE
Update Makefile and fix distutils dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,20 +2,20 @@
 
 # Install dependencies & fetch data
 install:
-	./startup.sh
+	./startup.sh lagged_oil_unrate
 
 # Download FRED data (if needed)
 data:
-	./startup.sh scripts/refresh_data.py
+	./startup.sh refresh_data
 
 # Default 18-month lag plot
 plot:
-	./startup.sh
+	./startup.sh lagged_oil_unrate
 
 # Custom plot of arbitrary series
 # Usage: make plot-custom ARGS="--series UNRATE CPIAUCSL --start 2000-01-01"
 plot-custom:
-	./startup.sh python scripts/custom_chart.py $(ARGS)
+	./startup.sh custom_chart $(ARGS)
 
 # Run tests
 test:


### PR DESCRIPTION
## Summary
- update Makefile targets to use chart aliases
- stub out distutils for Python 3.12 compatibility

## Testing
- `PIP_FIND_LINKS=wheelhouse PIP_NO_INDEX=1 make test`

------
https://chatgpt.com/codex/tasks/task_b_683baa6736bc832b8217def5f5223b9f