### PR TITLE
Switch CI to Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Cache wheelhouse
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary
- update CI configuration to use Python 3.12 instead of 3.11

## Testing
- `./startup.sh pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_683c67214574832b80c05d7d138a2074