### PR TITLE
Use wheelhouse via PIP_FIND_LINKS

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -21,7 +21,11 @@ if [[ "${PIP_NO_INDEX:-}" != "1" ]]; then
 fi
 
 echo "📦 Installing dependencies from $REQ_FILE…"
-pip install --upgrade -r "$REQ_FILE"
+pip_args=(--upgrade)
+if [[ -n "${PIP_FIND_LINKS:-}" ]]; then
+  pip_args+=(--find-links "$PIP_FIND_LINKS" --no-index)
+fi
+pip install "${pip_args[@]}" -r "$REQ_FILE"
 
 if [[ ! -f "$DATA_DB" ]]; then
   echo "🔄 data/fred.db missing; running refresh_data…"


### PR DESCRIPTION
## Summary
- respect `PIP_FIND_LINKS` in `startup.sh` so CI installs from the wheelhouse

## Testing
- `PIP_FIND_LINKS=wheelhouse ./startup.sh pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683c67284ddc832ba8d05594d7905f2f