### PR TITLE
Add Python linters to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,15 @@ jobs:
       - name: Install pytest
         run: pip install pytest
 
+      - name: Install linters
+        run: pip install flake8 black isort
+
+      - name: Run linters
+        run: |
+          flake8 .
+          black --check .
+          isort --check .
+
       - name: Run tests
         env:
           PIP_FIND_LINKS: wheelhouse


### PR DESCRIPTION
## Summary
- install flake8, black, and isort in CI
- run lint checks before tests

## Testing
- `PIP_FIND_LINKS=wheelhouse PIP_NO_INDEX=1 ./startup.sh pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683c6730fc70832bb9469ebd39dded3f